### PR TITLE
Use stdlib.h imports instead of malloc.h for better portability.

### DIFF
--- a/compute-accuracy.c
+++ b/compute-accuracy.c
@@ -16,7 +16,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include <malloc.h>
 #include <ctype.h>
 
 const long long max_size = 2000;         // max length of strings

--- a/distance.c
+++ b/distance.c
@@ -15,7 +15,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <malloc.h>
 
 const long long max_size = 2000;         // max length of strings
 const long long N = 40;                  // number of closest words that will be shown

--- a/word-analogy.c
+++ b/word-analogy.c
@@ -15,7 +15,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <malloc.h>
 
 const long long max_size = 2000;         // max length of strings
 const long long N = 40;                  // number of closest words that will be shown


### PR DESCRIPTION
To increase portability, most notably for macOS, I've removed the malloc.h
imports since malloc is already imported implicitly through stdlib.h.