### PR TITLE
Prevent last thread from exiting early on multiple iterations

### DIFF
--- a/word2vec.c
+++ b/word2vec.c
@@ -424,6 +424,7 @@ void *TrainModelThread(void *id) {
       last_word_count = 0;
       sentence_length = 0;
       fseek(fi, file_size / (long long)num_threads * (long long)id, SEEK_SET);
+      eof = 0;
       continue;
     }
     word = sen[sentence_position];


### PR DESCRIPTION
The thread handling the last part of the file wasn't resetting eof to 0 before the second iteration, so it skipped the computations for the remaining iterations.