### PR TITLE
Remove unnecessary if-statement

### DIFF
--- a/word2vec.c
+++ b/word2vec.c
@@ -427,7 +427,6 @@ void *TrainModelThread(void *id) {
       continue;
     }
     word = sen[sentence_position];
-    if (word == -1) continue;
     for (c = 0; c < layer1_size; c++) neu1[c] = 0;
     for (c = 0; c < layer1_size; c++) neu1e[c] = 0;
     next_random = next_random * (unsigned long long)25214903917 + 11;


### PR DESCRIPTION
The if statement `if (word == -1) continue;` will never evaluate to `true` because when filling the `sen` array, words with id `-1` are already being discarded by [this](https://github.com/tmikolov/word2vec/blob/master/word2vec.c#L404) check a few lines above.

I suggest to remove the if-statement because it is misleading and if it every evaluated to `true`, it would do so in the next iteration again (because `sentence_position` would not change) and the program would be in an infinite loop.