### PR TITLE
Update demo-classes.sh to properly decompress zip file instead of assuming gz

### DIFF
--- a/demo-classes.sh
+++ b/demo-classes.sh
@@ -1,7 +1,7 @@
 make
 if [ ! -e text8 ]; then
-  wget http://mattmahoney.net/dc/text8.zip -O text8.gz
-  gzip -d text8.gz -f
+  wget http://mattmahoney.net/dc/text8.zip -O text8.zip
+  unzip text8.zip
 fi
 time ./word2vec -train text8 -output classes.txt -cbow 1 -size 200 -window 8 -negative 25 -hs 0 -sample 1e-4 -threads 20 -iter 15 -classes 500
 sort classes.txt -k 2 -n > classes.sorted.txt


### PR DESCRIPTION
Script assumes gz incorrectly and leads to improper decompression of archive.

Handle file as a zip and correct functionality is observed. After changes in this PR:
![image](https://user-images.githubusercontent.com/9968657/221984920-145d7468-c450-498b-96c5-350aa6b2b1d2.png)

